### PR TITLE
Fixed/Simplified the pre-release PR_BODY text

### DIFF
--- a/.github/workflows/update-release.yaml
+++ b/.github/workflows/update-release.yaml
@@ -249,11 +249,7 @@ jobs:
           
           if [ "$IS_PRERELEASE" == "true" ]; then
             PR_TITLE="[Pre-release] Brew formula update for xiond version ${{ steps.version.outputs.tag }}"
-            PR_BODY="Updates the Homebrew versioned formulas for xiond pre-release ${{ steps.version.outputs.tag }}.
-
-**Note:** This is a pre-release. The main \`xiond.rb\` formula is unchanged (users running \`brew install xiond\` will still get the latest stable release).
-
-To install this pre-release: \`brew install burnt-labs/xion/xiond@${{ steps.version.outputs.version }}\`"
+            PR_BODY="Updates the Homebrew versioned formulas for xiond pre-release ${{ steps.version.outputs.tag }}. Note: This is a pre-release. The main xiond.rb formula is unchanged (users running brew install xiond will still get the latest stable release). To install this pre-release: brew install burnt-labs/xion/xiond@${{ steps.version.outputs.version }}"
           else
             PR_TITLE="Brew formula update for xiond version ${{ steps.version.outputs.tag }}"
             PR_BODY="Updates the Homebrew formula for xiond to version ${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
Adjusts the text used for the automated pre-release Homebrew update pull request messaging.

Changes:

Replaces the pre-release PR_BODY from a multi-line Markdown-formatted string to a single-line plain-text string.