### PR TITLE
DO-238 : Fix: Invalid workflow file

### DIFF
--- a/.github/workflows/update-release.yaml
+++ b/.github/workflows/update-release.yaml
@@ -249,11 +249,9 @@ jobs:
           
           if [ "$IS_PRERELEASE" == "true" ]; then
             PR_TITLE="[Pre-release] Brew formula update for xiond version ${{ steps.version.outputs.tag }}"
-            PR_BODY="Updates the Homebrew versioned formulas for xiond pre-release ${{ steps.version.outputs.tag }}.
-
-**Note:** This is a pre-release. The main \`xiond.rb\` formula is unchanged (users running \`brew install xiond\` will still get the latest stable release).
-
-To install this pre-release: \`brew install burnt-labs/xion/xiond@${{ steps.version.outputs.version }}\`"
+            PR_BODY="Updates the Homebrew versioned formulas for xiond pre-release ${{ steps.version.outputs.tag }}."
+            PR_BODY="$PR_BODY"$'\n\n'"**Note:** This is a pre-release. The main \`xiond.rb\` formula is unchanged (users running \`brew install xiond\` will still get the latest stable release)."
+            PR_BODY="$PR_BODY"$'\n\n'"To install this pre-release: \`brew install burnt-labs/xion/xiond@${{ steps.version.outputs.version }}\`"
           else
             PR_TITLE="Brew formula update for xiond version ${{ steps.version.outputs.tag }}"
             PR_BODY="Updates the Homebrew formula for xiond to version ${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
- Split the multi-line string into three concatenated assignments using $'\n\n' for the blank-line separators. 
- Each assignment line is properly indented within the YAML block, and the resulting PR_BODY value still contains the intended newlines and markdown formatting.