### PR TITLE
chore: Add CODEOWNERS file with proper team assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+* @burnt-labs/burnt-engineering/burnt-devops
+
+.github/ @burnt-labs/burnt-engineering/burnt-devops
+vitest.config.ts @burnt-labs/burnt-engineering/burnt-devops
+eslint.config.* @burnt-labs/burnt-engineering/burnt-devops

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
 * @burnt-labs/burnt-engineering/burnt-devops
 
 .github/ @burnt-labs/burnt-engineering/burnt-devops
-vitest.config.ts @burnt-labs/burnt-engineering/burnt-devops
-eslint.config.* @burnt-labs/burnt-engineering/burnt-devops


### PR DESCRIPTION
Adds CODEOWNERS file to assign code review responsibilities to appropriate teams. DevOps team owns CI/CD and configuration files (.github/, vitest.config.ts, eslint config).